### PR TITLE
Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"


### PR DESCRIPTION
Add `dependabot.yml` to check the version updates of GitHub Actions.

For detail, see below.

- https://docs.github.com/ja/code-security/supply-chain-security/keeping-your-actions-up-to-date-with-dependabot